### PR TITLE
Sample() function will never pick the last item

### DIFF
--- a/lang/arraylist.go
+++ b/lang/arraylist.go
@@ -115,7 +115,7 @@ func (self *ArrayList) Sample() interface{} {
 	if (self.count == 0) {
 		return nil
 	}
-	index := rand.Intn(self.count-1)
+	index := rand.Intn(self.count)
 	return self.items[index]
 }
 


### PR DESCRIPTION
See http://play.golang.org/p/BIh-FL_CUH (runs better locally though, playground seems to always return the same results)

Intn(x) will return a number that is from 0 to n-1. In `main.go`, when running the program, Hicham is never picked when doing `ArrayList.Sample()`.
