### PR TITLE
Add Stack.Get() and a Stack.Dump() methods.

### DIFF
--- a/lang/stack.go
+++ b/lang/stack.go
@@ -28,7 +28,11 @@
 
 package lang
 
-import "sync"
+import (
+	"sync"
+	"errors"
+	"fmt"
+)
 
 type stacknode struct {
 	data interface{}
@@ -46,6 +50,34 @@ func NewStack() *Stack {
 	s := &Stack{}
 	s.lock = &sync.Mutex{}
 	return s
+}
+
+// Get() peeks at the n-th item in the stack. Unlike other operations, this one costs O(n).
+func (s *Stack) Get(index int) (interface{}, error) {
+	if index < 0 || index >= s.count {
+		return nil, errors.New(fmt.Sprintf("Requested index %d outside stack, length %d", index, s.count))
+	}
+
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	n := s.head
+	for i := 1 ; i < s.count - index ; i++ {
+		n = n.next
+	}
+
+	return n.data, nil
+}
+
+// Dump() prints a textual representation of the stack.
+func (s *Stack) Dump() {
+	n := s.head
+	fmt.Print("[ ")
+  for i := 0 ; i < s.count ; i++ {
+		fmt.Printf("%+v ", n.data)
+		n = n.next
+	}
+	fmt.Print("]")
 }
 
 func (s *Stack) Len() int {
@@ -98,6 +130,6 @@ func (s *Stack) Peek() interface{} {
 	if n == nil || n.data == nil {
 		return nil
 	}
-	
+
 	return n.data
 }


### PR DESCRIPTION
Sometimes it is useful to be able to access the n-th element in a Queue/Stack. You have this in the Java Stack, for instance. Of course, unlike Push/Pop/Peek, this would be an O(n) operation, considering your implementation.

This PR is just an example. It also includes a Dump() helper method to show the contents of the Stack.
